### PR TITLE
fix: fixed CrashLoopBackOff issue in graphite-remote-adapter when deploying

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ COPY web/ web/
 
 # Install LZ4 libraries to build
 RUN apk add --no-cache \
-        openssl=3.5.1-r0 \
+        openssl=3.5.2-r0 \
         make=4.4.1-r3 \
         build-base=0.5-r3 \
         lz4-dev=1.10.0-r0 \

--- a/charts/graphite-remote-adapter/templates/deployment.yaml
+++ b/charts/graphite-remote-adapter/templates/deployment.yaml
@@ -49,7 +49,6 @@ spec:
             {{- end }}
           {{- end }}
           args:
-            - /bin/graphite-remote-adapter
             - '--config.file=/graphite-remote-adapter/additionalGraphiteConfig.yaml'
             - '--graphite.write.carbon-address={{ .Values.writeCarbonAddress }}'
             - '--graphite.write.carbon-transport=tcp'


### PR DESCRIPTION
resolve: https://github.com/Netcracker/qubership-monitoring-operator/issues/142