### PR TITLE
fix(renovate): sync Alpine repositories safely

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -34,7 +34,7 @@ jobs:
   test:
     needs: prepare
     name: Build and test with coverage
-    uses: Netcracker/qubership-core-infra/.github/workflows/generic-go-build.yaml@bc2a0bd082147e23b4091616c608a21cc2957728 # v2.4.1
+    uses: Netcracker/qubership-core-infra/.github/workflows/generic-go-build.yaml@71206242f5967ac6691337913593f8623863f711 # v2.5.2
     with:
       go-module-dir: '.'
       sonar-project-key: ${{ needs.prepare.outputs.sonar-project-key }}

--- a/.github/workflows/renovate-config-lint.yaml
+++ b/.github/workflows/renovate-config-lint.yaml
@@ -24,4 +24,4 @@ jobs:
           persist-credentials: false
 
       - name: Validate renovate.json
-        run: docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest renovate-config-validator renovate.json
+        run: docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest renovate-config-validator --strict --no-global renovate.json

--- a/.github/workflows/renovate-config-lint.yaml
+++ b/.github/workflows/renovate-config-lint.yaml
@@ -1,0 +1,27 @@
+name: Validate Renovate Config
+run-name: "Ref: ${{ github.ref_name }}. On ${{ github.event_name }}"
+
+on:
+  push:
+    paths:
+      - renovate.json
+      - .github/workflows/renovate-config-lint.yaml
+  pull_request:
+    paths:
+      - renovate.json
+      - .github/workflows/renovate-config-lint.yaml
+
+jobs:
+  validate-renovate-config:
+    name: Validate renovate.json
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Validate renovate.json
+        run: docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest renovate-config-validator renovate.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,15 +42,15 @@ COPY web/ web/
 COPY VERSION VERSION
 
 # Install LZ4 libraries to build
-# renovate: datasource=repology depName=alpine_3_23/openssl versioning=loose alpine-minor=3.23
-ARG OPENSSL_VERSION=3.5.6-r0
-# renovate: datasource=repology depName=alpine_3_23/make versioning=loose alpine-minor=3.23
+# renovate: datasource=repology depName=alpine_3_23/openssl versioning=apk
+ARG OPENSSL_VERSION=3.5.7-r0
+# renovate: datasource=repology depName=alpine_3_23/make versioning=apk
 ARG MAKE_VERSION=4.4.1-r3
-# renovate: datasource=repology depName=alpine_3_23/build-base versioning=loose alpine-minor=3.23
+# renovate: datasource=repology depName=alpine_3_23/build-base versioning=apk
 ARG BUILD_BASE_VERSION=0.5-r3
-# renovate: datasource=repology depName=alpine_3_23/lz4-dev versioning=loose alpine-minor=3.23
+# renovate: datasource=repology depName=alpine_3_23/lz4-dev versioning=apk
 ARG LZ4_DEV_VERSION=1.10.0-r0
-# renovate: datasource=repology depName=alpine_3_23/lz4 versioning=loose alpine-minor=3.23
+# renovate: datasource=repology depName=alpine_3_23/lz4 versioning=apk
 ARG LZ4_VERSION=1.10.0-r0
 RUN apk add --no-cache \
         openssl=${OPENSSL_VERSION} \
@@ -84,7 +84,7 @@ COPY NOTICE /usr/share/doc/graphite-remote-adapter/NOTICE
 COPY LICENSE /usr/share/doc/graphite-remote-adapter/LICENSE
 
 # Install runtime dependencies
-# renovate: datasource=repology depName=alpine_3_23/lz4-libs versioning=loose alpine-minor=3.23
+# renovate: datasource=repology depName=alpine_3_23/lz4-libs versioning=apk syncWith=alpine
 ARG LZ4_LIBS_VERSION=1.10.0-r0
 RUN apk add --no-cache lz4-libs=${LZ4_LIBS_VERSION}
 

--- a/docs/internal/development/developer-guide.md
+++ b/docs/internal/development/developer-guide.md
@@ -15,7 +15,7 @@
 
 * [Go version](https://go.dev/dl/) version `1.21+`
 * [Windows Subsystem for Linux 2 (WSL2)](https://docs.microsoft.com/en-us/windows/wsl/install)
-* [Ubuntu for WSL2](https://canonical-ubuntu-wsl.readthedocs-hosted.com/en/latest/guides/install-ubuntu-wsl2/)
+* [Ubuntu for WSL2](https://documentation.ubuntu.com/wsl/latest/guides/install-ubuntu-wsl2/)
 * Docker on wsl.
 * IDE for Go, we recommended to use:
   * either [Visual Studio Code](https://code.visualstudio.com/), free

--- a/renovate.json
+++ b/renovate.json
@@ -2,39 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "schedule:weekly"
+    "schedule:weekly",
+    "github>Netcracker/renovate-config:annotated-versions"
   ],
   "labels": [
     "dependencies"
   ],
   "prConcurrentLimit": 20,
-  "customManagers": [
-    {
-      "customType": "regex",
-      "description": "Update versions via inline renovate annotation comments",
-      "managerFilePatterns": [
-        "/^Dockerfile$/"
-      ],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>[^\\s]+)(?: versioning=(?<versioning>[a-z-0-9]+))?[^\\n]*\\n[^\\n]*?(?<currentValue>[0-9][^\\s\"'\\n<]*)"
-      ],
-      "extractVersionTemplate": "^v?(?<version>.+)$"
-    },
-    {
-      "customType": "regex",
-      "description": "Update Alpine minor version in repology depName annotations and keep them in sync with the base image",
-      "managerFilePatterns": [
-        "/^Dockerfile$/"
-      ],
-      "matchStrings": [
-        "# renovate: datasource=repology depName=alpine_\\d+_\\d+/(?<depName>[^\\s]+) versioning=loose alpine-minor=(?<currentValue>[\\d.]+)"
-      ],
-      "autoReplaceStringTemplate": "# renovate: datasource=repology depName=alpine_{{newMajor}}_{{newMinor}}/{{depName}} versioning=loose alpine-minor={{newValue}}",
-      "datasourceTemplate": "docker",
-      "packageNameTemplate": "alpine",
-      "versioningTemplate": "docker"
-    }
-  ],
   "packageRules": [
     {
       "description": "All GitHub Actions - grouped by default",
@@ -59,6 +33,12 @@
       "matchPackageNames": ["ghcr.io/netcracker/**"],
       "groupName": "netcracker-docker-images",
       "separateMajorMinor": false
+    },
+    {
+      "description": "Alpine runtime image and synchronized package repository",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["alpine"],
+      "groupName": "alpine-release"
     },
     {
       "description": "Kubernetes-related Go modules",

--- a/renovate.json
+++ b/renovate.json
@@ -1,55 +1,25 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    "schedule:weekly",
+    "github>Netcracker/renovate-config:base",
+    "github>Netcracker/renovate-config:github-actions",
+    "github>Netcracker/renovate-config:go",
+    "github>Netcracker/renovate-config:netcracker-dependencies",
     "github>Netcracker/renovate-config:annotated-versions"
-  ],
-  "labels": [
-    "dependencies"
   ],
   "prConcurrentLimit": 20,
   "packageRules": [
     {
-      "description": "All GitHub Actions - grouped by default",
-      "matchManagers": ["github-actions"],
-      "groupName": "actions-deps"
-    },
-    {
-      "description": "Netcracker GitHub Actions and reusable workflows",
-      "matchManagers": ["github-actions"],
-      "matchPackageNames": ["Netcracker/**", "netcracker/**"],
-      "groupName": "netcracker-github-actions",
-      "separateMajorMinor": false
-    },
-    {
       "description": "All 3rd party Docker images and APK packages",
       "matchManagers": ["dockerfile", "custom.regex"],
+      "matchPackageNames": ["!ghcr.io/netcracker/**"],
       "groupName": "docker-deps"
-    },
-    {
-      "description": "Netcracker Docker images",
-      "matchManagers": ["dockerfile"],
-      "matchPackageNames": ["ghcr.io/netcracker/**"],
-      "groupName": "netcracker-docker-images",
-      "separateMajorMinor": false
     },
     {
       "description": "Alpine runtime image and synchronized package repository",
       "matchDatasources": ["docker"],
       "matchPackageNames": ["alpine"],
       "groupName": "alpine-release"
-    },
-    {
-      "description": "Kubernetes-related Go modules",
-      "matchManagers": ["gomod"],
-      "matchPackageNames": ["k8s.io/**", "sigs.k8s.io/**"],
-      "groupName": "go-k8s"
-    },
-    {
-      "description": "All other Go dependencies",
-      "matchManagers": ["gomod"],
-      "groupName": "go-deps"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,13 @@
     {
       "description": "All 3rd party Docker images and APK packages",
       "matchManagers": ["dockerfile", "custom.regex"],
-      "matchPackageNames": ["!ghcr.io/netcracker/**"],
+      "matchPackageNames": [
+        "!ghcr.io/netcracker/**",
+        "!golang",
+        "!docker.io/library/golang",
+        "!index.docker.io/library/golang",
+        "!registry-1.docker.io/library/golang"
+      ],
       "groupName": "docker-deps"
     },
     {


### PR DESCRIPTION
## Why

The local Alpine manager ties all Repology annotations to the runtime Alpine image. In [PR #135](https://github.com/Netcracker/qubership-graphite-remote-adapter/pull/135), updating the runtime image to Alpine 3.24 also rewrites builder annotations to `alpine_3_24`, although the builder remains on `golang:*-alpine3.23`.

The existing Go workflow also uses a Sonar scanner that requires an unavailable Java runtime, and the developer guide links to a removed Ubuntu WSL page.

## What

- Replace the local regex managers with `github>Netcracker/renovate-config:annotated-versions`.
- Replace copied dependency groups with the shared organization presets.
- Use APK versioning for all six pinned Alpine packages.
- Synchronize only the runtime `lz4-libs` repository with the official Alpine image.
- Preserve the `alpine-release` group after the broader Docker grouping rule.
- Keep official Go builder images in the shared Go toolchain group.
- Refresh the OpenSSL pin for Alpine 3.23.
- Add strict repository-config validation.
- Update the reusable Go workflow to `v2.5.2` for the supported Sonar setup.
- Replace the removed Ubuntu WSL link with the current documentation URL.

Related shared configuration: [Netcracker/renovate-config#29](https://github.com/Netcracker/renovate-config/pull/29).